### PR TITLE
🔀 :: UiState로 상태관리시 에러 메시지가 사라지지 않음

### DIFF
--- a/presentation/src/main/java/com/daily/presentation/view/auth/component/EmailInput.kt
+++ b/presentation/src/main/java/com/daily/presentation/view/auth/component/EmailInput.kt
@@ -37,7 +37,7 @@ fun EmailInput(
 
     val errorRes = when {
         isEmailValid == false -> R.string.email_format_not_valid
-        isEmailUnique == false -> R.string.email_is_already_exist
+        isEmailUnique == false && onClicked -> R.string.email_is_already_exist
         else -> null
     }
 
@@ -53,6 +53,7 @@ fun EmailInput(
         ) {
             email = it
             isEmailValid = PatternsCompat.EMAIL_ADDRESS.matcher(it).matches()
+            onClicked = false
         }
         errorRes?.let {
             Caption1(

--- a/presentation/src/main/java/com/daily/presentation/view/auth/verification/VerificationScreen.kt
+++ b/presentation/src/main/java/com/daily/presentation/view/auth/verification/VerificationScreen.kt
@@ -28,6 +28,7 @@ fun VerificationScreen(
 ) {
     var code by remember { mutableStateOf("") }
     var isMatched by remember { mutableStateOf(true) }
+    var isComplete by remember { mutableStateOf(false) }
 
     val uiState by viewModel.verifyUiState.collectAsStateWithLifecycle()
 
@@ -79,15 +80,17 @@ fun VerificationScreen(
                 value = code,
                 length = CODE_LENGTH,
                 onValueChange = {
+                    isComplete = false
                     if (it.length <= CODE_LENGTH) {
                         code = it
-                        if (code.length == CODE_LENGTH) {
-                            viewModel.verifyAuthKey(code.toInt())
-                        }
+                    }
+                    if (code.length == CODE_LENGTH) {
+                        viewModel.verifyAuthKey(code.toInt())
+                        isComplete = true
                     }
                 }
             )
-            if (!isMatched) {
+            if (!isMatched && isComplete) {
                 Spacer(modifier = modifier.height(12.dp))
                 Caption1(
                     text = stringResource(R.string.verification_code_not_matching),


### PR DESCRIPTION
- EmailInput에서 버튼을 클릭한 경우만 이메일 중복 메시지 출력하도록 변경
- VerificationScreen에서 인증코드를 모두 입력한 경우에만 불일치하는 경우 메시지 출력하도록 변경