### PR TITLE
🔀 :: 캘린더에서 Month 변경시 뷰가 제대로 그려지지 않음

### DIFF
--- a/designsystem/src/main/java/com/daily/designsystem/component/calendar/DailyCalendar.kt
+++ b/designsystem/src/main/java/com/daily/designsystem/component/calendar/DailyCalendar.kt
@@ -123,23 +123,24 @@ private fun DayItem(
     monthDays: MonthDay,
     onClickItem: (day: Int) -> Unit
 ) {
+    val isToday = LocalDate.now().isEqual(LocalDate.of(selectedDay.year, monthDays.month, monthDays.day))
+
     Box(
         modifier = Modifier
             .fillMaxSize()
             .aspectRatio(1f)
             .padding(9.dp)
             .background(
-                color = if (selectedDay.dayOfMonth == monthDays.day) DailyTheme.color.Black else Color.Transparent,
+                color = if (isToday) DailyTheme.color.Black else Color.Transparent,
                 shape = RoundedCornerShape(12.dp),
             )
             .dailyClickable(rippleEnable = false) {
                 onClickItem(monthDays.day)
             }
     ) {
-        val isSelected = LocalDate.now().isEqual(LocalDate.of(selectedDay.year, monthDays.month, monthDays.day))
         val isAnotherMonth = LocalDate.now().monthValue != monthDays.month
         val textColor = when {
-            isSelected -> DailyColor.White
+            isToday -> DailyColor.White
             isAnotherMonth -> DailyColor.FeatureColor.AnotherMonthColor
             else -> DailyColor.FeatureColor.CalendarDayColor
         }

--- a/designsystem/src/main/java/com/daily/designsystem/component/calendar/DailyCalendar.kt
+++ b/designsystem/src/main/java/com/daily/designsystem/component/calendar/DailyCalendar.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -38,13 +39,13 @@ fun DailyCalendar(
     modifier: Modifier = Modifier,
     onClickItem: (day: Int) -> Unit
 ) {
-    val selectedDay by remember { mutableStateOf(LocalDate.now()) }
+    var selectedDay by remember { mutableStateOf(LocalDate.now()) }
 
     Column(modifier = modifier.fillMaxWidth()) {
         CalendarTopBar(
             month = selectedDay.month.name,
-            showPreviousMonth = { selectedDay.minusMonths(1) },
-            showNextMonth = { selectedDay.plusMonths(1) }
+            showPreviousMonth = { selectedDay = selectedDay.minusMonths(1) },
+            showNextMonth = { selectedDay = selectedDay.plusMonths(1) }
         )
         Spacer(modifier = modifier.height(20.dp))
         DayOfWeekBar()

--- a/designsystem/src/main/java/com/daily/designsystem/component/calendar/DailyCalendar.kt
+++ b/designsystem/src/main/java/com/daily/designsystem/component/calendar/DailyCalendar.kt
@@ -138,7 +138,7 @@ private fun DayItem(
                 onClickItem(monthDays.day)
             }
     ) {
-        val isAnotherMonth = LocalDate.now().monthValue != monthDays.month
+        val isAnotherMonth = LocalDate.now().monthValue == selectedDay.monthValue && LocalDate.now().monthValue != monthDays.month
         val textColor = when {
             isToday -> DailyColor.White
             isAnotherMonth -> DailyColor.FeatureColor.AnotherMonthColor


### PR DESCRIPTION
- 버튼 클릭시 selectedDay 값 변경하도록 변경
- 오늘 날짜 포커스시 년, 월, 일 모두 비교하도록 변경
- LocalDate의 monthValue가 이번달인 경우만 textColor, fontSize가 변경되도록 수정