### PR TITLE
🔀 :: (#171) transparent status bar refactoring

### DIFF
--- a/app/src/main/java/com/daily/daily/StatusBar.kt
+++ b/app/src/main/java/com/daily/daily/StatusBar.kt
@@ -1,16 +1,11 @@
 package com.daily.daily
 
 import android.graphics.Color
-import android.os.Build
 import android.view.Window
-import androidx.annotation.RequiresApi
-import androidx.core.view.WindowInsetsControllerCompat
+import androidx.core.view.WindowCompat
 
-@RequiresApi(Build.VERSION_CODES.R)
 fun Window.setTransparentStatusBar() {
-    this.apply {
-        statusBarColor = Color.TRANSPARENT
-        setDecorFitsSystemWindows(false)
-        WindowInsetsControllerCompat(this, this.decorView).isAppearanceLightStatusBars = true
-    }
+    statusBarColor = Color.TRANSPARENT
+    WindowCompat.setDecorFitsSystemWindows(this, false)
+    WindowCompat.getInsetsController(this, this.decorView).isAppearanceLightStatusBars = true
 }


### PR DESCRIPTION
- api level 제한으로 window.setDecorFitsSystemWindows 대신 WindowCompat 사용
- WindowInsetsControllerCompat 대신 WindowCompat에서 인스턴스 받도록 변경